### PR TITLE
[BB-1170] Fix users display name

### DIFF
--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -27,7 +27,7 @@ func (o *groupResourceType) ResourceType(_ context.Context) *v2.ResourceType {
 	return o.resourceType
 }
 
-func groupResource(ctx context.Context, group client.Group) (*v2.Resource, error) {
+func groupResource(group client.Group) (*v2.Resource, error) {
 	profile := map[string]interface{}{
 		"group_id":   group.ID,
 		"group_name": group.Name,
@@ -50,7 +50,7 @@ func groupResource(ctx context.Context, group client.Group) (*v2.Resource, error
 	return resource, nil
 }
 
-func (o *groupResourceType) List(ctx context.Context, resourceId *v2.ResourceId, pt *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (o *groupResourceType) List(ctx context.Context, _ *v2.ResourceId, pt *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
 	bag := &pagination.Bag{}
 	err := bag.Unmarshal(pt.Token)
 	if err != nil {
@@ -68,8 +68,7 @@ func (o *groupResourceType) List(ctx context.Context, resourceId *v2.ResourceId,
 
 	rv := make([]*v2.Resource, 0, len(resp.Groups))
 	for _, g := range resp.Groups {
-		groupCopy := g
-		gr, err := groupResource(ctx, groupCopy)
+		gr, err := groupResource(g)
 		if err != nil {
 			return nil, "", nil, err
 		}
@@ -87,7 +86,7 @@ func (o *groupResourceType) List(ctx context.Context, resourceId *v2.ResourceId,
 	return rv, nextPage, annotations, nil
 }
 
-func (o *groupResourceType) Entitlements(ctx context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
+func (o *groupResourceType) Entitlements(_ context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
 	var rv []*v2.Entitlement
 
 	assignmentOptions := []ent.EntitlementOption{
@@ -101,7 +100,7 @@ func (o *groupResourceType) Entitlements(ctx context.Context, resource *v2.Resou
 	return rv, "", nil, nil
 }
 
-func (o *groupResourceType) Grants(ctx context.Context, resource *v2.Resource, pt *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
+func (o *groupResourceType) Grants(ctx context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
 	resp, err := o.client.ListGroupGrants(ctx, resource.Id.Resource)
 	if err != nil {
 		return nil, "", nil, err

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -8,7 +8,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
 	ent "github.com/conductorone/baton-sdk/pkg/types/entitlement"
-	grant "github.com/conductorone/baton-sdk/pkg/types/grant"
+	"github.com/conductorone/baton-sdk/pkg/types/grant"
 	res "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/conductorone/baton-twingate/pkg/connector/client"
 )
@@ -27,7 +27,7 @@ func (o *roleResourceType) ResourceType(_ context.Context) *v2.ResourceType {
 	return o.resourceType
 }
 
-func roleResource(ctx context.Context, role *client.Role) (*v2.Resource, error) {
+func roleResource(role *client.Role) (*v2.Resource, error) {
 	profile := map[string]interface{}{
 		"role_id":   role.Id,
 		"role_name": role.Name,
@@ -50,7 +50,7 @@ func roleResource(ctx context.Context, role *client.Role) (*v2.Resource, error) 
 	return resource, nil
 }
 
-func (o *roleResourceType) List(ctx context.Context, _ *v2.ResourceId, pt *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (o *roleResourceType) List(ctx context.Context, _ *v2.ResourceId, _ *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
 	roles, err := o.client.ListRoles(ctx)
 	if err != nil {
 		return nil, "", nil, err
@@ -58,9 +58,7 @@ func (o *roleResourceType) List(ctx context.Context, _ *v2.ResourceId, pt *pagin
 
 	rv := make([]*v2.Resource, 0, len(roles))
 	for _, r := range roles {
-		roleCopy := r
-
-		rr, err := roleResource(ctx, roleCopy)
+		rr, err := roleResource(r)
 		if err != nil {
 			return nil, "", nil, err
 		}
@@ -70,7 +68,7 @@ func (o *roleResourceType) List(ctx context.Context, _ *v2.ResourceId, pt *pagin
 	return rv, "", nil, nil
 }
 
-func (o *roleResourceType) Entitlements(ctx context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
+func (o *roleResourceType) Entitlements(_ context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
 	var rv []*v2.Entitlement
 
 	assignmentOptions := []ent.EntitlementOption{

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -7,7 +7,7 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
-	resource "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/conductorone/baton-twingate/pkg/connector/client"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
@@ -23,7 +23,7 @@ func (o *userResourceType) ResourceType(_ context.Context) *v2.ResourceType {
 	return o.resourceType
 }
 
-func userResource(ctx context.Context, user *client.User) (*v2.Resource, error) {
+func userResource(user *client.User) (*v2.Resource, error) {
 	profile := map[string]interface{}{
 		"first_name": user.FirstName,
 		"last_name":  user.LastName,
@@ -38,8 +38,10 @@ func userResource(ctx context.Context, user *client.User) (*v2.Resource, error) 
 		resource.WithStatus(v2.UserTrait_Status_STATUS_ENABLED),
 	}
 
+	displayName := getDisplayName(user.Email, user.FirstName, user.LastName)
+
 	resource, err := resource.NewUserResource(
-		fmt.Sprintf("%s %s", user.FirstName, user.LastName),
+		displayName,
 		resourceTypeUser,
 		user.ID,
 		userTraitOptions,
@@ -49,6 +51,18 @@ func userResource(ctx context.Context, user *client.User) (*v2.Resource, error) 
 	}
 
 	return resource, nil
+}
+
+func getDisplayName(email, firstName, lastName string) string {
+	if firstName == "" && lastName == "" {
+		return email
+	}
+
+	if firstName == "" {
+		return lastName
+	}
+
+	return fmt.Sprintf("%s %s", firstName, lastName)
 }
 
 func (o *userResourceType) List(ctx context.Context, _ *v2.ResourceId, pt *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
@@ -77,8 +91,7 @@ func (o *userResourceType) List(ctx context.Context, _ *v2.ResourceId, pt *pagin
 			continue
 		}
 
-		userCopy := user
-		ur, err := userResource(ctx, userCopy)
+		ur, err := userResource(user)
 		if err != nil {
 			return nil, "", nil, err
 		}


### PR DESCRIPTION
When the users have an empty name, the email is used as a display name for the resource.