### PR TITLE
[CXH-748] feat: add role provisioning

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,10 +20,10 @@ jobs:
           go-version-file: go.mod
       - name: Build baton-twingate
         run: go build ./cmd/baton-twingate
-      # Role grant/revoke. The connector is set-style: granting devops demotes the test
-      # principal from MEMBER, then revoking demotes it back to MEMBER, leaving a stable
-      # state for the next run. The principal is a dedicated CI user (baton-ci@example.com)
-      # that is safe to mutate.
+      # Role grant/revoke against a dedicated CI user (baton-ci@example.com) that is safe
+      # to mutate. The connector is set-style: revoke demotes to MEMBER, grant sets DEVOPS.
+      # sync-test runs revoke-then-grant, so each run exercises both paths and leaves the
+      # principal at DEVOPS — a stable, repeatable end state for the next run.
       # Role test runs before any group test — group membership can produce inherited
       # grants via expansion that would otherwise skew the role assertion.
       - name: Test role grant/revoke

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,12 +12,12 @@ jobs:
       BATON_DOMAIN: ${{ vars.BATON_DOMAIN }}
       BATON_API_KEY: ${{ secrets.BATON_API_KEY }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
       - name: Install Go
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - name: Checkout code
-        uses: actions/checkout@v6
       - name: Build baton-twingate
         run: go build ./cmd/baton-twingate
       # Role grant/revoke. The connector is set-style: granting devops demotes the test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,8 +7,10 @@ on:
       - main
 jobs:
   test:
-    if: false  # Remove this line to enable integration tests
     runs-on: ubuntu-latest
+    env:
+      BATON_DOMAIN: ${{ vars.BATON_DOMAIN }}
+      BATON_API_KEY: ${{ secrets.BATON_API_KEY }}
     steps:
       - name: Install Go
         uses: actions/setup-go@v6
@@ -16,15 +18,18 @@ jobs:
           go-version-file: go.mod
       - name: Checkout code
         uses: actions/checkout@v6
-      # Build the connector binary, then run sync-test.
-      # Configure with valid entitlement/principal IDs.
-      # Add additional test jobs as needed.
       - name: Build baton-twingate
         run: go build ./cmd/baton-twingate
-      - name: Test connector syncing
+      # Role grant/revoke. The connector is set-style: granting devops demotes the test
+      # principal from MEMBER, then revoking demotes it back to MEMBER, leaving a stable
+      # state for the next run. The principal is a dedicated CI user (baton-ci@example.com)
+      # that is safe to mutate.
+      # Role test runs before any group test — group membership can produce inherited
+      # grants via expansion that would otherwise skew the role assertion.
+      - name: Test role grant/revoke
         uses: ConductorOne/github-workflows/actions/sync-test@v4
         with:
           connector: ./baton-twingate
-          baton-entitlement: '<entitlement-id>'
-          baton-principal: '<principal-id>'
+          baton-entitlement: 'role:devops:member'
+          baton-principal: ${{ vars.BATON_TEST_PRINCIPAL }}
           baton-principal-type: 'user'

--- a/baton_capabilities.json
+++ b/baton_capabilities.json
@@ -24,7 +24,8 @@
         ]
       },
       "capabilities": [
-        "CAPABILITY_SYNC"
+        "CAPABILITY_SYNC",
+        "CAPABILITY_PROVISION"
       ],
       "permissions": {}
     },

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -16,7 +16,7 @@ sidebarTitle: Twingate
 | :----------- | :--- | :-------- |
 | Accounts     | <Icon icon="square-check" iconType="solid"  color="#c937ae"/>   |           |       
 | Groups       | <Icon icon="square-check" iconType="solid"  color="#c937ae"/>    | <Icon icon="square-check" iconType="solid"  color="#c937ae"/>   | 
-| Roles        | <Icon icon="square-check" iconType="solid"  color="#c937ae"/>    |   |
+| Roles        | <Icon icon="square-check" iconType="solid"  color="#c937ae"/>    | <Icon icon="square-check" iconType="solid"  color="#c937ae"/>   |
 
 ## Gather Twingate credentials 
 

--- a/pkg/connector/client/queries.go
+++ b/pkg/connector/client/queries.go
@@ -14,6 +14,7 @@ const (
         createdAt
         updatedAt
         isAdmin
+        role
         state
       }
   }
@@ -70,6 +71,26 @@ const (
 		  error
 		}
 	}`
+
+	// getUserQuery fetches a single user's current role for idempotency pre-flight checks.
+	getUserQuery = `query{
+		user(id: "%s") {
+			id
+			email
+			isAdmin
+			role
+			state
+		}
+	}`
+
+	// userRoleUpdateQuery sets a user's role. `role` is a GraphQL UserRole enum and must
+	// NOT be quoted. Docs: https://www.twingate.com/docs/api#definition-UserRoleUpdateMutation
+	userRoleUpdateQuery = `mutation{
+		userRoleUpdate(id: "%s", role: %s) {
+		  ok
+		  error
+		}
+	}`
 )
 
 func allUsersQuery(pg *string, pageSize uint32) string {
@@ -86,6 +107,14 @@ func groupsQuery(pg *string, pageSize uint32) string {
 	} else {
 		return fmt.Sprintf(getGroupsQuery, *pg, pageSize)
 	}
+}
+
+func getUserQueryFormat(userID string) string {
+	return fmt.Sprintf(getUserQuery, userID)
+}
+
+func userRoleUpdateQueryFormat(userID string, role string) string {
+	return fmt.Sprintf(userRoleUpdateQuery, userID, role)
 }
 
 func addGroupMemberQueryFormat(groupID string, userID string) string {

--- a/pkg/connector/client/twingate.go
+++ b/pkg/connector/client/twingate.go
@@ -417,7 +417,7 @@ func (c *ConnectorClient) UpdateUserRole(ctx context.Context, userID string, rol
 	resp := &UserRoleUpdateResponse{}
 	rld, err := c.query(ctx, userRoleUpdateQueryFormat(userID, role), resp, nil)
 	if err != nil {
-		return rld, fmt.Errorf("twingate-client: error updating user role for %s: %w", c.Domain, err)
+		return rld, fmt.Errorf("twingate-client: error updating role to %s for user %s on %s: %w", role, userID, c.Domain, err)
 	}
 	if len(resp.Errors) > 0 {
 		return rld, fmt.Errorf("twingate: graphql error: %s", resp.Errors[0].Message)

--- a/pkg/connector/client/twingate.go
+++ b/pkg/connector/client/twingate.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
@@ -99,6 +100,32 @@ type User struct {
 	FirstName string `json:"firstName"`
 	LastName  string `json:"lastName"`
 	IsAdmin   bool   `json:"isAdmin"`
+	// Role is the UserRole enum value: ADMIN, DEVOPS, SUPPORT, ACCESS_REVIEWER, or MEMBER.
+	// Bucket role grants on this field, NOT isAdmin (isAdmin is true for all but MEMBER).
+	Role string `json:"role"`
+}
+
+// GraphQLError is a top-level GraphQL error entry (validation errors, e.g. a bad enum).
+// These land in the response's top-level `errors[]`, NOT in data.<op>.error.
+type GraphQLError struct {
+	Message string `json:"message"`
+}
+
+type UserRoleUpdateResponse struct {
+	Data struct {
+		UserRoleUpdate struct {
+			Ok    bool    `json:"ok"`
+			Error *string `json:"error"`
+		} `json:"userRoleUpdate"`
+	} `json:"data"`
+	Errors []GraphQLError `json:"errors"`
+}
+
+type GetUserResponse struct {
+	Data struct {
+		User *User `json:"user"`
+	} `json:"data"`
+	Errors []GraphQLError `json:"errors"`
 }
 
 type PageInfo struct {
@@ -112,7 +139,32 @@ type Group struct {
 	IsActive bool   `json:"isActive,omitempty"`
 }
 
-var defaultRoles = []*Role{{Name: "Admin", Id: "admin"}, {Name: "Member", Id: "member"}}
+// defaultRoles models all 5 Twingate UserRole enum values. The enum is ADMIN, DEVOPS,
+// SUPPORT, ACCESS_REVIEWER, MEMBER — modeling only Admin/Member mis-buckets the middle
+// three (which all report isAdmin=true) as Admin.
+var defaultRoles = []*Role{
+	{Id: "admin", Name: "Admin"},
+	{Id: "devops", Name: "DevOps"},
+	{Id: "support", Name: "Support"},
+	{Id: "access_reviewer", Name: "Access Reviewer"},
+	{Id: "member", Name: "Member"},
+}
+
+// roleEnumByID maps an internal role ID to the on-wire UserRole enum. An explicit table
+// decouples role IDs from enum names (no strings.ToUpper) and fails loudly on unknown roles.
+var roleEnumByID = map[string]string{
+	"admin":           "ADMIN",
+	"devops":          "DEVOPS",
+	"support":         "SUPPORT",
+	"access_reviewer": "ACCESS_REVIEWER",
+	"member":          "MEMBER",
+}
+
+// RoleEnumByID returns the UserRole enum for a role ID, and whether the role is known.
+func RoleEnumByID(roleID string) (string, bool) {
+	enum, ok := roleEnumByID[roleID]
+	return enum, ok
+}
 
 type GroupGrant struct {
 	GroupID     string
@@ -344,6 +396,41 @@ func (c *ConnectorClient) GrantGroupMembership(ctx context.Context, groupID stri
 	return rv, nil
 }
 
+// GetUser fetches a single user's current state for an idempotency pre-flight read.
+// Returns a nil User (no error) when the user does not exist (data.user is null).
+func (c *ConnectorClient) GetUser(ctx context.Context, userID string) (*User, *v2.RateLimitDescription, error) {
+	resp := &GetUserResponse{}
+	rld, err := c.query(ctx, getUserQueryFormat(userID), resp, nil)
+	if err != nil {
+		return nil, rld, fmt.Errorf("twingate-client: error getting user %s for %s: %w", userID, c.Domain, err)
+	}
+	if len(resp.Errors) > 0 {
+		return nil, rld, fmt.Errorf("twingate: graphql error: %s", resp.Errors[0].Message)
+	}
+	return resp.Data.User, rld, nil
+}
+
+// UpdateUserRole sets a user's role via the userRoleUpdate mutation. role is the on-wire
+// UserRole enum (e.g. "ADMIN", "MEMBER"). It surfaces top-level GraphQL errors (e.g. a bad
+// enum), which land in errors[] and do NOT populate data.userRoleUpdate.
+func (c *ConnectorClient) UpdateUserRole(ctx context.Context, userID string, role string) (*v2.RateLimitDescription, error) {
+	resp := &UserRoleUpdateResponse{}
+	rld, err := c.query(ctx, userRoleUpdateQueryFormat(userID, role), resp, nil)
+	if err != nil {
+		return rld, fmt.Errorf("twingate-client: error updating user role for %s: %w", c.Domain, err)
+	}
+	if len(resp.Errors) > 0 {
+		return rld, fmt.Errorf("twingate: graphql error: %s", resp.Errors[0].Message)
+	}
+	if !resp.Data.UserRoleUpdate.Ok {
+		if resp.Data.UserRoleUpdate.Error != nil {
+			return rld, fmt.Errorf("twingate: api error: '%s'", *resp.Data.UserRoleUpdate.Error)
+		}
+		return rld, fmt.Errorf("twingate: unable to update role to %s for user %s", role, userID)
+	}
+	return rld, nil
+}
+
 func (c *ConnectorClient) RevokeGroupMembership(ctx context.Context, groupID string, userID string) (*RevokeEntitlementResponse, error) {
 	resp := &GrantAndRevokeGroupResponse{}
 	rateLimitDescription, err := c.query(ctx, removeGroupMemberQueryFormat(groupID, userID), resp, nil)
@@ -373,18 +460,18 @@ func (c *ConnectorClient) ListRoleGrants(ctx context.Context, roleID string, pag
 	if err != nil {
 		return nil, fmt.Errorf("twingate-client: error getting role grants for %s: %w", c.Domain, err)
 	}
+	// Bucket on user.role (the UserRole enum), NOT isAdmin — isAdmin is true for ADMIN,
+	// DEVOPS, SUPPORT, AND ACCESS_REVIEWER, so it cannot distinguish them.
+	targetEnum, ok := roleEnumByID[roleID]
 	grants := make([]RoleGrant, 0, len(resp.Data.Users.Edges))
-	for _, user := range resp.Data.Users.Edges {
-		if roleID == "admin" && user.User.IsAdmin {
-			grants = append(grants, RoleGrant{
-				PrincipalID: user.User.ID,
-				RoleID:      roleID,
-			})
-		} else if roleID == "member" && !user.User.IsAdmin {
-			grants = append(grants, RoleGrant{
-				PrincipalID: user.User.ID,
-				RoleID:      roleID,
-			})
+	if ok {
+		for _, user := range resp.Data.Users.Edges {
+			if strings.EqualFold(user.User.Role, targetEnum) {
+				grants = append(grants, RoleGrant{
+					PrincipalID: user.User.ID,
+					RoleID:      roleID,
+				})
+			}
 		}
 	}
 	pg := ""

--- a/pkg/connector/client/twingate.go
+++ b/pkg/connector/client/twingate.go
@@ -451,6 +451,12 @@ func (c *ConnectorClient) RevokeGroupMembership(ctx context.Context, groupID str
 }
 
 func (c *ConnectorClient) ListRoleGrants(ctx context.Context, roleID string, pagination string, pageSize uint32) (*RoleGrantsResponse, error) {
+	// Fail loud on an unknown role ID — guards against drift where a role is added to
+	// defaultRoles but not roleEnumByID, which would otherwise silently drop its grants.
+	targetEnum, ok := roleEnumByID[roleID]
+	if !ok {
+		return nil, fmt.Errorf("twingate-client: unknown role ID %q", roleID)
+	}
 	var pagePointer *string = nil
 	if pagination != "" {
 		pagePointer = &pagination
@@ -462,16 +468,13 @@ func (c *ConnectorClient) ListRoleGrants(ctx context.Context, roleID string, pag
 	}
 	// Bucket on user.role (the UserRole enum), NOT isAdmin — isAdmin is true for ADMIN,
 	// DEVOPS, SUPPORT, AND ACCESS_REVIEWER, so it cannot distinguish them.
-	targetEnum, ok := roleEnumByID[roleID]
 	grants := make([]RoleGrant, 0, len(resp.Data.Users.Edges))
-	if ok {
-		for _, user := range resp.Data.Users.Edges {
-			if strings.EqualFold(user.User.Role, targetEnum) {
-				grants = append(grants, RoleGrant{
-					PrincipalID: user.User.ID,
-					RoleID:      roleID,
-				})
-			}
+	for _, user := range resp.Data.Users.Edges {
+		if strings.EqualFold(user.User.Role, targetEnum) {
+			grants = append(grants, RoleGrant{
+				PrincipalID: user.User.ID,
+				RoleID:      roleID,
+			})
 		}
 	}
 	pg := ""

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -3,6 +3,7 @@ package connector
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
@@ -11,6 +12,8 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/types/grant"
 	res "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/conductorone/baton-twingate/pkg/connector/client"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -122,6 +125,93 @@ func (o *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, pt
 		annotations.WithRateLimiting(resp.RateLimitDescription)
 	}
 	return rv, nextPage, annotations, nil
+}
+
+// Grant sets a user's Twingate role via userRoleUpdate. Twingate roles are set-style — each
+// user holds exactly one role, so granting any role replaces the current one. A pre-flight
+// read is required because the API does not signal "already has this role".
+func (o *roleResourceType) Grant(ctx context.Context, principal *v2.Resource, entitlement *v2.Entitlement) (annotations.Annotations, error) {
+	outputAnnotations := annotations.Annotations{}
+
+	if principal.Id.ResourceType != resourceTypeUser.Id {
+		return nil, status.Errorf(codes.InvalidArgument, "twingate: principal must be a user, got %s", principal.Id.ResourceType)
+	}
+
+	roleID := entitlement.Resource.Id.Resource
+	userID := principal.Id.Resource
+
+	targetEnum, ok := client.RoleEnumByID(roleID)
+	if !ok {
+		return nil, status.Errorf(codes.InvalidArgument, "twingate: unknown role: %s", roleID)
+	}
+
+	user, rld, err := o.client.GetUser(ctx, userID)
+	if rld != nil {
+		outputAnnotations.WithRateLimiting(rld)
+	}
+	if err != nil {
+		return outputAnnotations, err
+	}
+	if user == nil {
+		return outputAnnotations, status.Errorf(codes.NotFound, "twingate: user %s not found", userID)
+	}
+	if strings.EqualFold(user.Role, targetEnum) {
+		outputAnnotations.Append(&v2.GrantAlreadyExists{})
+		return outputAnnotations, nil
+	}
+
+	rld2, err := o.client.UpdateUserRole(ctx, userID, targetEnum)
+	if rld2 != nil {
+		outputAnnotations.WithRateLimiting(rld2)
+	}
+	if err != nil {
+		return outputAnnotations, err
+	}
+	return outputAnnotations, nil
+}
+
+// Revoke demotes a user to MEMBER (Twingate's only "no privileged role" state). Revoking the
+// Member role itself is invalid — Twingate users always have a role.
+func (o *roleResourceType) Revoke(ctx context.Context, gr *v2.Grant) (annotations.Annotations, error) {
+	outputAnnotations := annotations.Annotations{}
+
+	roleID := gr.Entitlement.Resource.Id.Resource
+	userID := gr.Principal.Id.Resource
+
+	if roleID == "member" {
+		return outputAnnotations, status.Error(codes.InvalidArgument,
+			"twingate: cannot revoke the Member role — Twingate users always have a role; grant a different role to change it")
+	}
+
+	grantedEnum, ok := client.RoleEnumByID(roleID)
+	if !ok {
+		return outputAnnotations, status.Errorf(codes.InvalidArgument, "twingate: unknown role: %s", roleID)
+	}
+
+	user, rld, err := o.client.GetUser(ctx, userID)
+	if rld != nil {
+		outputAnnotations.WithRateLimiting(rld)
+	}
+	if err != nil {
+		return outputAnnotations, err
+	}
+	if user == nil {
+		return outputAnnotations, status.Errorf(codes.NotFound, "twingate: user %s not found", userID)
+	}
+	// If the user no longer holds the role we're revoking, the grant is already gone.
+	if !strings.EqualFold(user.Role, grantedEnum) {
+		outputAnnotations.Append(&v2.GrantAlreadyRevoked{})
+		return outputAnnotations, nil
+	}
+
+	rld2, err := o.client.UpdateUserRole(ctx, userID, "MEMBER")
+	if rld2 != nil {
+		outputAnnotations.WithRateLimiting(rld2)
+	}
+	if err != nil {
+		return outputAnnotations, err
+	}
+	return outputAnnotations, nil
 }
 
 func roleBuilder(client *client.ConnectorClient, domain string) *roleResourceType {


### PR DESCRIPTION
## Summary

Adds **grant/revoke provisioning for the Role resource type** via the Twingate `userRoleUpdate` mutation, and fixes a role-bucketing bug in `ListRoleGrants`.

Closes [CXH-748](https://linear.app/ductone/issue/CXH-748/twingate-add-provisioning-support-for-roles). **Supersedes #16** (broader scope: 5 roles vs 2, plus the listing-bug fix) — coordinate close-out with @russell.

## The bug this fixes

The previous implementation modeled only `Admin`/`Member` and bucketed users on `user.isAdmin`:

```go
var defaultRoles = []*Role{{Name: "Admin", Id: "admin"}, {Name: "Member", Id: "member"}}
...
if roleID == "admin" && user.User.IsAdmin {            // admin bucket = everyone with isAdmin=true
    grants = append(...)
} else if roleID == "member" && !user.User.IsAdmin {   // member bucket = everyone with isAdmin=false
    grants = append(...)
}
```

Live probes confirmed **`isAdmin` is `true` for `ADMIN`, `DEVOPS`, `SUPPORT`, AND `ACCESS_REVIEWER`** (false only for `MEMBER`) — i.e. `isAdmin` really means "has any non-Member role," not "is an Admin." So the `roleID == "admin" && user.User.IsAdmin` branch swept **all four** privileged roles into **Admin**, and since `defaultRoles` only contained `admin`/`member`, DevOps/Support/Access-Reviewer had **no representation of their own in C1 at all**.

The fix models all 5 `UserRole` enum values and buckets on `user.role` directly.

> [!WARNING]
> **Behavior change for existing tenants.** Customers running today with the `isAdmin` bucketing will see DEVOPS/SUPPORT/ACCESS_REVIEWER users move out of the "Admin" bucket into their correct role on the next sync. This is a correctness fix but downstream automations keying on the old (wrong) data should be aware.

## Changes

- **`queries.go`** — add `role` to the users query; add `getUser` + `userRoleUpdate` queries (`role` is an **unquoted** GraphQL enum) and formatters
- **`twingate.go`** — add `Role` to `User`; expand `defaultRoles` to 5; add `roleEnumByID` map + accessor; add `GetUser` and `UpdateUserRole` (surfaces top-level GraphQL `errors[]`, which validation errors land in — not `data.<op>.error`); fix `ListRoleGrants` to bucket on `user.role`
- **`role.go`** — add `Grant`/`Revoke` with pre-flight idempotency reads (`GrantAlreadyExists`/`GrantAlreadyRevoked`), principal-type guard, and refusal to revoke `MEMBER` (Twingate has no "no role" state — revoking any other role demotes to `MEMBER`)
- **`baton_capabilities.json`** — regenerated; Role gains `CAPABILITY_PROVISION`
- **`docs/connector.mdx`** — mark Roles as provisionable
- **`.github/workflows/ci.yaml`** — enable a real `sync-test` integration run (was a disabled scaffold); exercises role grant/revoke against the test tenant on every PR

## Verification

End-to-end against `batontest.twingate.com`:

| Test | Result |
|---|---|
| `go build` / `go vet` / `make lint` | pass (0 lint issues) |
| `baton-test run sync` | pass — 7 resources, 6 entitlements, 2 grants |
| `baton-test run grant-revoke role` (×2) | pass — grant→verify→revoke→verify |
| DEVOPS user buckets under **DevOps** (not Admin) | pass — the core fix, confirmed live |
| CI `sync-test` (role grant/revoke) | pass — runs against a dedicated CI user |

Local verification used a throwaway user created via `userCreate` and removed via `userDelete`; the tenant was restored to baseline. CI uses a dedicated persistent user (`baton-ci@example.com`) that is safe to mutate.

## Known follow-ups (out of scope)

1. `429` handling bug in `client.query()` (returns nil error with empty response)
2. Move GraphQL `fmt.Sprintf` interpolation to proper variables
3. Verify whether SCIM-synced users (`User.type`) are mutable via `userRoleUpdate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)