### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -33,15 +33,14 @@ func groupResource(group client.Group) (*v2.Resource, error) {
 		"group_name": group.Name,
 	}
 
-	groupTraitOptions := []res.GroupTraitOption{
-		res.WithGroupProfile(profile),
-	}
+	groupTraitOptions := []res.GroupTraitOption{}
 
 	resource, err := res.NewGroupResource(
 		group.Name,
 		resourceTypeGroup,
 		group.ID,
 		groupTraitOptions,
+		res.WithResourceProfile(profile),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -36,15 +36,14 @@ func roleResource(role *client.Role) (*v2.Resource, error) {
 		"role_name": role.Name,
 	}
 
-	roleTraitOptions := []res.RoleTraitOption{
-		res.WithRoleProfile(profile),
-	}
+	roleTraitOptions := []res.RoleTraitOption{}
 
 	resource, err := res.NewRoleResource(
 		role.Name,
 		resourceTypeRole,
 		role.Id,
 		roleTraitOptions,
+		res.WithResourceProfile(profile),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -33,9 +33,7 @@ func userResource(user *client.User) (*v2.Resource, error) {
 	}
 
 	userTraitOptions := []resource.UserTraitOption{
-		resource.WithUserProfile(profile),
 		resource.WithEmail(user.Email, true),
-		resource.WithStatus(v2.UserTrait_Status_STATUS_ENABLED),
 	}
 
 	displayName := getDisplayName(user.Email, user.FirstName, user.LastName)
@@ -45,6 +43,8 @@ func userResource(user *client.User) (*v2.Resource, error) {
 		resourceTypeUser,
 		user.ID,
 		userTraitOptions,
+		resource.WithResourceProfile(profile),
+		resource.WithResourceStatus(v2.Status_RESOURCE_STATUS_ENABLED, ""),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
